### PR TITLE
Added derive clone for all types

### DIFF
--- a/src/bin/parse.rs
+++ b/src/bin/parse.rs
@@ -6,16 +6,16 @@ use std::error::Error;
 use std::fs;
 
 fn main() -> Result<(), Box<dyn Error>> {
-	let args: Vec<String> = env::args().collect();
-	match args.len() {
-		2 => {
-			let input = fs::read_to_string(&args[1])?;
-			let lx = Lexer::new(input.chars());
+    let args: Vec<String> = env::args().collect();
+    match args.len() {
+        2 => {
+            let input = fs::read_to_string(&args[1])?;
+            let lx = Lexer::new(input.chars());
             let mut pr = Parser::new();
-			let mut res = pr.parse(lx)?;
-			res.visit(&mut Dumper::new())?;
-		}
-		_ => println!("main [input]"),
-	}
-	Ok(())
+            let mut res = pr.parse(lx)?;
+            res.visit(&mut Dumper::new())?;
+        }
+        _ => println!("main [input]"),
+    }
+    Ok(())
 }

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -156,7 +156,7 @@ impl<I: Iterator<Item = char>> Iterator for Lexer<I> {
                     if c == '\r' && d.map_or(false, |d| d == '\n') {
                         self.bump();
                     }
-                    continue
+                    continue;
                 }
                 (Some('['), _) => {
                     self.bump();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,8 +1,8 @@
 extern crate getset;
 
 pub mod dumper;
-pub mod lexer;
 #[allow(dead_code)]
 mod grammar;
+pub mod lexer;
 pub mod parser;
 pub mod syntax;

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -46,13 +46,26 @@ macro_rules! define_type {
     };
 }
 
-define_type!(Design, Module, ModuleStmt, Wire, Memory, Cell, Process, ProcessSync, ProcessSwitch, ProcessSwitchCase, Connect, Signal);
+define_type!(
+    Design,
+    Module,
+    ModuleStmt,
+    Wire,
+    Memory,
+    Cell,
+    Process,
+    ProcessSync,
+    ProcessSwitch,
+    ProcessSwitchCase,
+    Connect,
+    Signal
+);
 
 pub trait Visitor {
-	fn enter(&mut self, n: Node) -> Result<()>;
-	fn leave(&mut self, n: Node) -> Result<()>;
+    fn enter(&mut self, n: Node) -> Result<()>;
+    fn leave(&mut self, n: Node) -> Result<()>;
 }
 
 pub trait Visit {
-	fn visit<F: Visitor>(&mut self, f: &mut F) -> Result<()>;
+    fn visit<F: Visitor>(&mut self, f: &mut F) -> Result<()>;
 }

--- a/src/syntax/cell.rs
+++ b/src/syntax/cell.rs
@@ -12,7 +12,7 @@ bitflags! {
     }
 }
 
-#[derive(Debug, Getters, MutGetters)]
+#[derive(Debug, Getters, MutGetters, Clone)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct CellParam {
@@ -39,13 +39,13 @@ impl fmt::Display for CellParam {
     }
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum CellOption {
     Param((CellFlag, String, Const)),
     Connect((String, SigSpec)),
 }
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Default, Getters, MutGetters, Clone)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Cell {

--- a/src/syntax/connect.rs
+++ b/src/syntax/connect.rs
@@ -1,7 +1,7 @@
 use super::*;
 use getset::*;
 
-#[derive(Debug, Getters, MutGetters)]
+#[derive(Debug, Clone, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Connect {

--- a/src/syntax/constant.rs
+++ b/src/syntax/constant.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug)]
 pub enum Const {
     Empty,
     Sig(Signal),

--- a/src/syntax/design.rs
+++ b/src/syntax/design.rs
@@ -1,28 +1,28 @@
 use super::*;
 use getset::*;
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Clone, Default, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Design {
     autoidx: usize,
-	modules: Vec<Module>,
-	attrs: HashMap<String, Const>,
+    modules: Vec<Module>,
+    attrs: HashMap<String, Const>,
 }
 
 impl Design {
-	pub fn new() -> Self {
-		Self::default()
-	}
+    pub fn new() -> Self {
+        Self::default()
+    }
 }
 
 impl Visit for Design {
-	fn visit<F: Visitor>(&mut self, f: &mut F) -> Result<()> {
-		f.enter(Node::Design(self))?;
-		for n in self.modules.iter_mut() {
-			n.visit(f)?;
-		}
-		f.leave(Node::Design(self))?;
-		Ok(())
-	}
+    fn visit<F: Visitor>(&mut self, f: &mut F) -> Result<()> {
+        f.enter(Node::Design(self))?;
+        for n in self.modules.iter_mut() {
+            n.visit(f)?;
+        }
+        f.leave(Node::Design(self))?;
+        Ok(())
+    }
 }

--- a/src/syntax/memory.rs
+++ b/src/syntax/memory.rs
@@ -1,14 +1,14 @@
 use super::*;
 use getset::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum MemoryOption {
     Width(i64),
     Offset(i64),
     Size(i64),
 }
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Clone, Default, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Memory {

--- a/src/syntax/module.rs
+++ b/src/syntax/module.rs
@@ -45,6 +45,7 @@ impl Module {
                 ModuleStmt::Cell(n) => r.cells.push(n),
                 ModuleStmt::Process(n) => r.processes.push(n),
                 ModuleStmt::Memory(n) => r.memories.push(n),
+                ModuleStmt::Connect(n) => r.connects.push(n),
                 _ => (),
             };
         }

--- a/src/syntax/module.rs
+++ b/src/syntax/module.rs
@@ -1,7 +1,7 @@
 use super::*;
 use getset::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ModuleStmt {
     Empty,
     Param(String),
@@ -13,7 +13,7 @@ pub enum ModuleStmt {
     Process(Process),
 }
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Clone, Default, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Module {
@@ -37,10 +37,10 @@ impl Module {
             match stmt {
                 ModuleStmt::Param(n) => {
                     r.params.insert(n, Const::Empty);
-                },
+                }
                 ModuleStmt::ParamVal((k, v)) => {
                     r.params.insert(k, v);
-                },
+                }
                 ModuleStmt::Wire(n) => r.wires.push(n),
                 ModuleStmt::Cell(n) => r.cells.push(n),
                 ModuleStmt::Process(n) => r.processes.push(n),

--- a/src/syntax/process.rs
+++ b/src/syntax/process.rs
@@ -1,7 +1,7 @@
 use super::*;
 use getset::*;
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Clone, Default, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct ProcessSwitchCase {
@@ -43,7 +43,7 @@ impl Visit for ProcessSwitchCase {
     }
 }
 
-#[derive(Debug, Getters, MutGetters)]
+#[derive(Debug, Clone, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct ProcessSwitch {
@@ -79,7 +79,7 @@ pub enum ProcessStmt {
     Switch(ProcessSwitch),
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum ProcessSyncType {
     Always,
     Global,
@@ -91,7 +91,7 @@ pub enum ProcessSyncType {
     Edge(SigSpec),
 }
 
-#[derive(Debug, Getters, MutGetters)]
+#[derive(Debug, Clone, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct ProcessSync {
@@ -118,7 +118,7 @@ impl Visit for ProcessSync {
     }
 }
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Clone, Default, Getters, MutGetters)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Process {

--- a/src/syntax/sigspec.rs
+++ b/src/syntax/sigspec.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum SigSpec {
     Const((Const, i64, i64)),
     Refer((String, i64, i64)),

--- a/src/syntax/wire.rs
+++ b/src/syntax/wire.rs
@@ -12,7 +12,7 @@ pub enum WireOption {
     Inout(i64),
 }
 
-#[derive(Debug, Default, Getters, MutGetters)]
+#[derive(Debug, Default, Getters, MutGetters, Clone)]
 #[get = "pub"]
 #[get_mut = "pub"]
 pub struct Wire {


### PR DESCRIPTION
this is usually expected, and I would like to have it available for my use-case.

also, simple pass of `cargo fmt`.

